### PR TITLE
page_menu are now with uniquie id

### DIFF
--- a/app/views/refinery/admin/menu_links/_menu_link.html.erb
+++ b/app/views/refinery/admin/menu_links/_menu_link.html.erb
@@ -1,4 +1,4 @@
-<%= fields_for 'page_menu[links_attributes]', menu_link do |f| %>
+<%= fields_for "page_menu[links_attributes][#{dom_id(menu_link)}]", menu_link do |f| %>
   <li class='pp-link clearfix record' id="<%= dom_id(menu_link)%>">
     <div class='header'>
       <div class='name'><%= menu_link.label %></div>


### PR DESCRIPTION
let me start from the beginning . 
When you use this gem with `2.0.5` version and put the following things in 
`$cat config/initializers/refinery/page_menus.rb` 

```
Refinery::PageMenus.configure do |config|
 config.menu_resources = {:refinery_page=>
  { klass: 'Refinery::Page',
                        title_attr: 'title',
                        admin_page_filter: {
                            draft: false
                        }
    }
  }   
end
```

Then, when you goes to `http://0.0.0.0:3000/refinery/page_menus/1/edit` where `1` is id of `page_menus` which you like to edit .
Now  add 5-6 `Refiney Pages` into it and try changing its labels. Now checks menus either by going frontend or open same edited file . You will see that only one menu has changed its label. 
So, **this the bug** . 
And this is the fix for it . 
