### PR TITLE
Replace admin filters with scopes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bundle
+
 # Ignore setup tests files
 spec/dummy/
 coverage/
@@ -12,29 +14,5 @@ wiki/
 
 # Other stuff
 .idea/
-.bundle/config
-bin/autospec
-bin/coderay
-bin/erubis
-bin/guard
-bin/htmldiff
-bin/launchy
-bin/ldiff
-bin/nokogiri
-bin/pry
-bin/rackup
-bin/rails
-bin/rake
-bin/rake2thor
-bin/rdoc
-bin/refinerycms
-bin/ri
-bin/rspec
-bin/sass
-bin/sass-convert
-bin/scss
-bin/spork
-bin/sprockets
-bin/thor
-bin/tilt
-bin/tt
+
+bin

--- a/app/models/refinery/menu_link.rb
+++ b/app/models/refinery/menu_link.rb
@@ -19,8 +19,8 @@ module Refinery
     def self.find_all_of_type(type)
       # find all resources of the given type, determined by the configuration
       # TODO - we may want to allow configuration of conditions (DONE), ordering, etc
-      if self.resource_config(type)[:admin_page_filter]
-        resource_klass(type).where(self.resource_config(type)[:admin_page_filter])
+      if scope = self.resource_config(type)[:scope]
+        scope.is_a?(Symbol) ? resource_klass(type).send(scope) : resource_klass(type).instance_eval(&scope)
       else
         resource_klass(type).all
       end

--- a/lib/refinery/page_menus/configuration.rb
+++ b/lib/refinery/page_menus/configuration.rb
@@ -10,14 +10,12 @@ module Refinery
     # klass: class type of resource
     # admin_partial: path to partial used in records list
     # title_attr: attribute name (or method name) on resource to be shown as its title
-    # admin_page_filter: hash of conditions to be used for filtering objects shown to be add-able via menu edit page
+    # scope: a scope symbol or proc to be used for filtering objects shown to be addable via the menu edit page
     self.menu_resources = {
       refinery_page: {
         klass: 'Refinery::Page',
         title_attr: 'title',
-        admin_page_filter: {
-          draft: false
-        }
+        scope: Proc.new { live.order('lft ASC') }
       },
       refinery_resource: {
         klass: 'Refinery::Resource',

--- a/readme.md
+++ b/readme.md
@@ -84,9 +84,7 @@ Here is a example of how Refinery Pages are added as a custom resource model:
 config.menu_resources = refinery_page: {
   							klass: 'Refinery::Page',
   							title_attr: 'title',
-  							admin_page_filter: {
-   				 				draft: false
-  							}
+  							scope: Proc.new { live.order('lft ASC') }
 						 }
 ```
 


### PR DESCRIPTION
Using scopes allows re-using existing code and also allows for ordering and so on.
