### PR TITLE
simple update of readme to reflect the gemspec changes renaming from refinerycms-...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ gem 'refinerycms-page-menus', '2.0.5'
 or for edge version
 
 ```ruby
-gem 'refinerycms-page-menus', git: 'git://github.com/pylonweb/refinerycms-menus.git'
+gem 'refinerycms-menus', git: 'git://github.com/pylonweb/refinerycms-menus.git'
 ```
 
 Next run


### PR DESCRIPTION
There was a small inconsistency between the documentation and the proper gem name as a result of the updated gem name. 
